### PR TITLE
#20: Update plugin to use background thread for REST polling

### DIFF
--- a/emulator_input_plugin/Makefile
+++ b/emulator_input_plugin/Makefile
@@ -242,7 +242,7 @@ clean:
 rebuild: clean all
 
 # build dependency files
-CFLAGS += -MD -MP
+CFLAGS += -MD -MP -lpthread
 -include $(OBJECTS:.o=.d)
 
 # standard build rules

--- a/emulator_input_plugin/src/controller.h
+++ b/emulator_input_plugin/src/controller.h
@@ -1,6 +1,6 @@
 #ifndef __CONTROLLER_H__
 #define __CONTROLLER_H__
 
-void read_controller(int Control);
+void read_controller();
 
 #endif // __CONTROLLER_H__

--- a/emulator_input_plugin/src/plugin.c
+++ b/emulator_input_plugin/src/plugin.c
@@ -5,6 +5,7 @@
 
 #include <unistd.h>
 #include <sys/socket.h>
+#include <pthread.h>
 
 #include "plugin.h"
 #include "version.h"
@@ -105,6 +106,10 @@ EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo)
     }
 
     DebugMessage(M64MSG_INFO, "%s version %i.%i.%i initialized.", PLUGIN_NAME, VERSION_PRINTF_SPLIT(PLUGIN_VERSION));
+
+    /* Start local controller service in new thread */
+    pthread_t thread_id;
+    pthread_create(&thread_id, NULL, read_controller, NULL);
 }
 
 /******************************************************************
@@ -174,7 +179,7 @@ EXPORT void CALL RomClosed(void)
 *******************************************************************/
 EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
 {
-    read_controller(Control);
+//    read_controller(Control);
 
     #ifdef _DEBUG
       DebugMessage(M64MSG_VERBOSE, "Controller #%d value: 0x%8.8X", 0, *(int *)&controller[Control].buttons );

--- a/emulator_input_plugin/src/plugin.h
+++ b/emulator_input_plugin/src/plugin.h
@@ -11,7 +11,7 @@ typedef struct
 } SController;
 
 /* global data definitions */
-extern SController controller[4]; // 1 controller
+extern SController controller[4]; // 4 controller
 
 /* global function definitions */
 extern void DebugMessage(int level, const char *message, ...);


### PR DESCRIPTION
Towards #20 

read_controller call has been removed on update, but instead a thread constantly executes the read_controller method for all controllers. This thread updates the controller set on the fly, and these changes are then sent back to the emulator at appropriate intervals.

This removes the issue of lag, caused by the blocking nature of TCP REST calls in the previous code.